### PR TITLE
Fix markdown and link text in scan_steps.md

### DIFF
--- a/pages/scan_steps.md
+++ b/pages/scan_steps.md
@@ -1,4 +1,4 @@
-_[This is a description of the step-by-step technical process by which we 'scan' each Target URL.  For information on the process of building the Target URL list, go [here](https://github.com/GSA/federal-website-index/blob/main/process/index-creation.md).]_
+_[This is a description of the step-by-step technical process by which we 'scan' each Target URL.  These steps come after the initial process of [building the Target URL list](https://github.com/GSA/federal-website-index/blob/main/process/index-creation.md).]_
 
 First off, before any scans take place, the process of ingesting the target URL list into the database populates the following fields: 
 * `Target URL`
@@ -13,11 +13,11 @@ When scanning commences, [this core file](https://github.com/GSA/site-scanning-e
 
 The [current scans](https://github.com/GSA/site-scanning-engine/tree/main/libs/core-scanner/src/pages) are: 
 
-- `[primary](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/primary.ts)` - Loads the Target URL and analyzes the resulting Final URL, generating most of the Site Scanning data.  
-- `[dns](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/dns.ts)` - Analyzes the DNS of the Final URL using a node.js library (instead of puppeteer).  
-- `[notFound](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/not-found.ts)` -  An https service (instead of puppeteer) is used to test for proper 404 behavoir.  
-- `[robotsTxt](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/robots-txt.ts)` - Appends `/robots.txt` to the Target URL, loads it, and analyzes the resulting `robots.txt` Final URL.  
-- `[sitemapXml](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/sitemap-xml.ts)` - Appends `/sitemap.xml` to the Target URL, loads it, and analyzes the resulting `sitemap.xml` Final URL.
+- [`primary`](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/primary.ts) - Loads the Target URL and analyzes the resulting Final URL, generating most of the Site Scanning data.  
+- [`dns`](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/dns.ts) - Analyzes the DNS of the Final URL using a Node.js library (instead of Puppeteer).  
+- [`notFound`](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/not-found.ts) -  Tests for proper 404 behavior using an https service (instead of Puppeteer).  
+- [`robotsTxt`](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/robots-txt.ts) - Appends `/robots.txt` to the Target URL, loads it, and analyzes the resulting `robots.txt` Final URL.  
+- [`sitemapXml`](https://github.com/GSA/site-scanning-engine/blob/main/libs/core-scanner/src/pages/sitemap-xml.ts) - Appends `/sitemap.xml` to the Target URL, loads it, and analyzes the resulting `sitemap.xml` Final URL.
 
 Each scan notes whether it Completed, or failed due to one of the following reasons: Timeout, DNS resolution error, Invalid SSL cert, Connection refused, Connection reset, or Unknown error.  These populate the `Scan Status - Primary`, `Scan Status - DNS`, `Scan Status - Not Found`, `Scan Status - Robots.txt`, and `Scan Status - Sitemap.xml` fields.  
 


### PR DESCRIPTION
Markdown for list of scans didn't seem to be working as intended. Fixed ambiguous "go here" link text at top. 

(I'm checking out the DX Indicators and reading the Site Scanner docs, and spotted a few formatting issues to fix if that's OK!)